### PR TITLE
Increase size limit on writes

### DIFF
--- a/NetworkStore.ts
+++ b/NetworkStore.ts
@@ -96,11 +96,14 @@ export class NetworkStore<T> {
     const sha = key.toString("hex");
     try {
       //   console.log("set", sha, value as any);
-      await fetch(this._url + "/" + sha, {
+      const response = await fetch(this._url + "/" + sha, {
         body: JSON.stringify(value),
         method: "PUT",
         compress: true,
       });
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
     } catch (error) {
       console.log("set err:", sha, error, value);
     }

--- a/metro-cache-endpoint/pages/api/store/[sha].ts
+++ b/metro-cache-endpoint/pages/api/store/[sha].ts
@@ -42,3 +42,11 @@ function getMethod(req: NextApiRequest): string {
   // @ts-ignore
   return req.method.toLowerCase();
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '1TB',
+    },
+  },
+}


### PR DESCRIPTION
1. The cache endpoint was previously rejecting large writes.
2. The client was previously not logging failed writes.